### PR TITLE
feat: Index TypeScript file by import without build (Bun.sh)

### DIFF
--- a/src/lib/indexer.ts
+++ b/src/lib/indexer.ts
@@ -122,7 +122,13 @@ export abstract class Indexer {
 
     protected abstract get ext(): string;
 
-    protected abstract generateFileContent(views: Source[], listeners: Source[]): Promise<string>;
+    async generateFileContent(views: Source[], listeners: Source[]): Promise<string> {
+        views.sort(compareSources);
+        listeners.sort(compareSources);
+        return `export type ViewName = ${views.map(v => `"${v.name}"`).join(" | ")};
+export type ListenerName = ${listeners.map(l => `"${l.name}"`).join(" | ")};
+`;
+    }
 
     static async index(conf: Conf, writeIndexFile: boolean = false) {
         const indexer = indexers[conf.indexer];
@@ -135,14 +141,6 @@ export class JavaScriptIndexer extends Indexer {
     get ext(): string {
         return "js";
     }
-    async generateFileContent(views: Source[], listeners: Source[]): Promise<string> {
-        views.sort(compareSources);
-        listeners.sort(compareSources);
-        return `export type ViewName = ${views.map(v => `"${v.name}"`).join(" | ")};
-export type ListenerName = ${listeners.map(l => `"${l.name}"`).join(" | ")};
-`;
-    }
-
 }
 
 export class TypeScriptIndexer extends JavaScriptIndexer {

--- a/src/lib/indexer.ts
+++ b/src/lib/indexer.ts
@@ -81,7 +81,7 @@ export abstract class Indexer {
         const sourcePromises = files.map(async file => {
             const path = join(dir, file.name);
             if (file.isDirectory()) return this.indexDirectory(indexedMap, [...parts, file.name], path);
-            else if (file.isFile() && file.name.endsWith('.js')) return this.indexFile(indexedMap, parts.slice(), path);
+            else if (file.isFile() && file.name.endsWith('.' + this.ext)) return this.indexFile(indexedMap, parts.slice(), path);
             return [];
         });
         return (await Promise.all(sourcePromises)).flat();


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
With Bun.sh you can use TypeScript files directly without transpiling then to JavaScript first.

This PR let the indexer manage this use case.



## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


